### PR TITLE
Load textcomp before gensymb to fix warning

### DIFF
--- a/ArticleTest.tex
+++ b/ArticleTest.tex
@@ -37,6 +37,7 @@
 \RequirePackage{amsfonts,amssymb,amsmath}
 
 % gensymb. Required for degrees symbol
+\RequirePackage{textcomp}  % load before gensymb for \micro and \perthousand
 \RequirePackage{gensymb}
 
 % better tables

--- a/meta.cls
+++ b/meta.cls
@@ -114,6 +114,7 @@
 \RequirePackage{amsfonts,amssymb,amsmath}
 
 % gensymb. Required for degrees symbol
+\RequirePackage{textcomp}  % load before gensymb for \micro and \perthousand
 \RequirePackage{gensymb}
 
 % better tables


### PR DESCRIPTION
gensymb complains about "Not defining" \micro and \perthousand. Fix this by loading
textcomp before gensymb.